### PR TITLE
made get_lexer_list.py run under Python 2.6

### DIFF
--- a/scripts/get_lexer_list.py
+++ b/scripts/get_lexer_list.py
@@ -6,7 +6,7 @@ import json
 ret = []
 
 def dictify(list):
-    return {k:True for k in list}
+    return dict([(k, True) for k in list])
 
 for fullname, names, exts, mimetypes in pygments.lexers.get_all_lexers():
     ret.append({


### PR DESCRIPTION
filebin does not require a specific Python version, it only requires pygmentize.
pygmentize requires Python 2.6, so filebin should not use Python 2.7 features
in its scripts.