### PR TITLE
Make sure that return_bytes function returns int value. Fix tabs.

### DIFF
--- a/application/helpers/filebin_helper.php
+++ b/application/helpers/filebin_helper.php
@@ -370,13 +370,13 @@ function files_are_equal($a, $b)
 # Source: http://php.net/manual/en/function.ini-get.php#96996
 function return_bytes($size_str)
 {
-    switch (substr ($size_str, -1))
-    {
-        case 'K': case 'k': return (int)$size_str * 1024;
-        case 'M': case 'm': return (int)$size_str * 1048576;
-        case 'G': case 'g': return (int)$size_str * 1073741824;
-        default: return $size_str;
-    }
+	switch (substr ($size_str, -1))
+	{
+		case 'K': case 'k': return (int)$size_str * 1024;
+		case 'M': case 'm': return (int)$size_str * 1048576;
+		case 'G': case 'g': return (int)$size_str * 1073741824;
+		default: return (int)$size_str;
+	}
 }
 
 # vim: set noet:


### PR DESCRIPTION
`php_admin_value[post_max_size]` in PHP fpm pool config set to big integer (i.e. 106954752) causes fb-client to crash if file is bigger than 10485760 bytes with traceback

    Traceback (most recent call last):
    [...]
     File "/usr/bin/fb", line 138, in upload_files
        if self.serverConfig is not None and (currentChunkSize + filesize > self.serverConfig["request_max_size"] \
    TypeError: unorderable types: int() > str()

because `api/v2.1.0/file/get_config` returns `"request_max_size"` as string

Server specs:
* Ubuntu 16.04
* Nginx 1.10
* PHP FPM 7.0.8