### PR TITLE
Alter database field type of 'filesize' to bigint to allow filesizes >2GB

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = true;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 18;
+$config['migration_version'] = 19;
 
 
 /*

--- a/application/migrations/019_change_filesize_type.php
+++ b/application/migrations/019_change_filesize_type.php
@@ -9,13 +9,13 @@ class Migration_change_filesize_type extends CI_Migration {
 
 		if ($this->db->dbdriver == 'postgre') {
 			$this->db->query('
-				ALTER TABLE "'.$prefix.'file_storage"
-					MODIFY `filesize` bigint;
+				ALTER TABLE `'.$prefix.'file_storage`
+					ALTER "filesize" TYPE bigint;
 				');
 		} else {
 			$this->db->query('
-				ALTER TABLE `'.$prefix.'file_storage`
-					ALTER "filesize" TYPE bigint;
+				ALTER TABLE "'.$prefix.'file_storage"
+					MODIFY `filesize` bigint;
 				');
 		}
 	}

--- a/application/migrations/019_change_filesize_type.php
+++ b/application/migrations/019_change_filesize_type.php
@@ -1,0 +1,27 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_change_filesize_type extends CI_Migration {
+
+	public function up()
+	{
+		$prefix = $this->db->dbprefix;
+
+		if ($this->db->dbdriver == 'postgre') {
+			$this->db->query('
+				ALTER TABLE "'.$prefix.'file_storage"
+					MODIFY `filesize` bigint;
+				');
+		} else {
+			$this->db->query('
+				ALTER TABLE `'.$prefix.'file_storage`
+					ALTER "filesize" TYPE bigint;
+				');
+		}
+	}
+
+	public function down()
+	{
+		throw new \exceptions\ApiException("migration/downgrade-not-supported", "downgrade not supported");
+	}
+}


### PR DESCRIPTION
The current type, `integer`, only stores numerics up to 2147483647. Since filebin stores the size in byte MySQL will only write up to 2GB in there, PostgreSQL failes by default for files >2GB.

The new type `bigint` allows file sizes up to ~9223 Petabyte.