### PR TITLE
Actually update filesize with update_file_metadata

### DIFF
--- a/application/controllers/file/file_default.php
+++ b/application/controllers/file/file_default.php
@@ -971,11 +971,14 @@ class File_default extends MY_Controller {
 
 			foreach ($query as $key => $item) {
 				$data_id = $item["hash"].'-'.$item['id'];
-				$mimetype = mimetype($this->mfile->file($data_id));
+				$filepath = $this->mfile->file($data_id);
+				$mimetype = mimetype($filepath);
+				$filesize = filesize($filepath);
 
 				$this->db->where('id', $item['id'])
 					->set(array(
 						'mimetype' => $mimetype,
+						'filesize' => $filesize,
 					))
 					->update('file_storage');
 			}


### PR DESCRIPTION
According to [`application/controllers/tools.php#L32`](https://github.com/Bluewind/filebin/blob/f8a57613ee33aa227aa829fdfc467125fe0da22c/application/controllers/tools.php#L32) the `update_file_metadata` tool should update the mimetype AND the filesize, but the latter never got implemented.