### PR TITLE
Use bigint for filesize in database

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = true;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 18;
+$config['migration_version'] = 19;
 
 
 /*

--- a/application/migrations/019_change_filesize_type.php
+++ b/application/migrations/019_change_filesize_type.php
@@ -21,7 +21,8 @@ class Migration_change_filesize_type extends CI_Migration {
 
 		$chunk = 500;
 
-		$total = $this->db->count_all("file_storage");
+		$this->db->where('filesize', 2147483647);
+		$total = $this->db->count_all_results("file_storage");
 
 		for ($limit = 0; $limit < $total; $limit += $chunk) {
 			$query = $this->db->select('hash, id')

--- a/application/migrations/019_change_filesize_type.php
+++ b/application/migrations/019_change_filesize_type.php
@@ -1,0 +1,27 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_change_filesize_type extends CI_Migration {
+
+	public function up()
+	{
+		$prefix = $this->db->dbprefix;
+
+		if ($this->db->dbdriver == 'postgre') {
+			$this->db->query('
+				ALTER TABLE "'.$prefix.'file_storage"
+					ALTER "filesize" TYPE bigint;
+				');
+		} else {
+			$this->db->query('
+				ALTER TABLE `'.$prefix.'file_storage`
+					MODIFY `filesize` bigint;
+				');
+		}
+	}
+
+	public function down()
+	{
+		throw new \exceptions\ApiException("migration/downgrade-not-supported", "downgrade not supported");
+	}
+}

--- a/application/migrations/019_change_filesize_type.php
+++ b/application/migrations/019_change_filesize_type.php
@@ -18,6 +18,29 @@ class Migration_change_filesize_type extends CI_Migration {
 					MODIFY `filesize` bigint;
 				');
 		}
+
+		$chunk = 500;
+
+		$total = $this->db->count_all("file_storage");
+
+		for ($limit = 0; $limit < $total; $limit += $chunk) {
+			$query = $this->db->select('hash, id')
+				->from('file_storage')
+				->where('filesize', 2147483647)
+				->limit($chunk, $limit)
+				->get()->result_array();
+
+			foreach ($query as $key => $item) {
+				$data_id = $item["hash"].'-'.$item['id'];
+				$filesize = filesize($this->mfile->file($data_id));
+
+				$this->db->where('id', $item['id'])
+					->set(array(
+						'filesize' => $filesize,
+					))
+					->update('file_storage');
+			}
+		}
 	}
 
 	public function down()


### PR DESCRIPTION
The current type, `integer`, only stores numerics up to 2147483647. Since filebin stores the size in byte MySQL will only write up to 2GB in there, PostgreSQL failes by default for files >2GB.

The new type `bigint` allows file sizes up to ~9223 petabyte.

The migration will also update all wrong filesizes, it will only update files with a filesize of 2147483647 byte since the database set the max integer value as the filesize if the file was > 2147483647 byte.