### PR TITLE
updated Dockerfile and README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
-MAINTAINER Sebastian Rakel <sebastian@devunit.eu>
+LABEL maintainer="sebastian@devunit.eu"
 
-RUN apk add --no-cache bash php7 py-pygments py2-pip imagemagick php7-gd nodejs composer php7-pdo_mysql php7-exif php7-ctype php7-session git php7-fileinfo msmtp
+RUN apk add --no-cache bash php7 py-pygments py-pip imagemagick php7-gd nodejs composer php7-pdo_mysql php7-exif php7-ctype php7-session git php7-fileinfo msmtp
 
 ENV FILEBIN_HOME_DIR /var/lib/filebin
 ENV FILEBIN_DIR $FILEBIN_HOME_DIR/filebin

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@
 Filebin is a paste service developed by Florian Pritz [https://paste.xinu.at/](https://paste.xinu.at/)
 
 ## Dockerfile
-[Dockerfile](https://git.server-speed.net/users/flo/filebin/tree/docker/Dockerfile)
+[Dockerfile](https://github.com/Bluewind/filebin/blob/master/Dockerfile)
 
 ## Ports
 The PHP webserver is listening on ```8080```


### PR DESCRIPTION
Hello,
after cloning the repository i wanted to try the filebin using docker and noticed that probably something is broken.

```
docker build -t filebin .
```
Here's the docker log

```
Sending build context to Docker daemon   55.4MB
Step 1/22 : FROM alpine:edge
 ---> 003bcf045729
Step 2/22 : MAINTAINER Sebastian Rakel <sebastian@devunit.eu>
 ---> Using cache
 ---> 6fe437802c72
Step 3/22 : RUN apk add --no-cache bash php7 py-pygments py2-pip imagemagick php7-gd nodejs composer php7-pdo_mysql php7-exif php7-ctype php7-session git php7-fileinfo msmtp
 ---> Running in 9fc0618396d4
fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  py2-pip (missing):
    required by: world[py2-pip]
The command '/bin/sh -c apk add --no-cache bash php7 py-pygments py2-pip imagemagick php7-gd nodejs composer php7-pdo_mysql php7-exif php7-ctype php7-session git php7-fileinfo msmtp' returned a non-zero code: 1
```

Probably the package `py2-pip` needs to be replaced with `py-pip`. 

I also noticed that the file `docker/README.md` had a broken link to the `Dockerfile` so i added that change too.
The `MAINTAINER` reference is also depreciated in Dockerfiles so I changed that to the `LABEL maintainer=`

Best regards.