### PR TITLE
get_lexer_list.py: Use python3 instead of python

### DIFF
--- a/scripts/get_lexer_list.py
+++ b/scripts/get_lexer_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pygments.lexers
 import json


### PR DESCRIPTION
Starting with the Debian 11 (bullseye) and Ubuntu 20.04 LTS (focal) releases, all python packages use explicit python3 or python2 interpreter and do not use unversioned /usr/bin/python at all. No packaged scripts should depend on the existence of '/usr/bin/python'.