### PR TITLE
Use systemd lexer for systemd .service file mimetypes

### DIFF
--- a/application/libraries/Pygments.php
+++ b/application/libraries/Pygments.php
@@ -112,6 +112,7 @@ class Pygments {
 		'application/x-shellscript' => 'bash',
 		'application/xslt+xml' => "xml",
 		'application/x-x509-ca-cert' => 'text',
+		'application/x-wine-extension-ini' => 'systemd',
 		'message/rfc822' => 'text',
 		'text/css' => 'css',
 		'text/html' => 'xml',


### PR DESCRIPTION
Uploading systemd foo.service files results in the application/x-wine-extension-ini mimetype, which triggers a download on various browsers. This fixes that and displays them using the systemd lexer instead.